### PR TITLE
Get real team name

### DIFF
--- a/iRTVO/Code/iRacingAPI.cs
+++ b/iRTVO/Code/iRacingAPI.cs
@@ -397,8 +397,11 @@ logger.Info("driverChange - data ready", "");
                                 }
                                 else
                                 {
+									// NT: No need to make up name, it's in the SDK:
+									driverItem.TeamName = parseStringValue(driver, "TeamName");
+									
                                     // make up generic teamname (to be parametrized in future)
-                                    driverItem.TeamName = "Team #" + driverItem.NumberPlate;
+                                    //driverItem.TeamName = "Team #" + driverItem.NumberPlate;
                                 }
                             }
 


### PR DESCRIPTION
No need to get a fake team name when no external data available as the real team name is now in the SDK. At the moment external data still has preference but in my opinion real team name should have preference..? Broadcasters might have 'old' teams.csv files lying around for hosted sessions and then broadcast an official race with incorrect team names due to the old file having preference over the actual real team name in iRacing. I'll leave that up to you to decide...
