### PR TITLE
Further additions

### DIFF
--- a/iRTVO.Interfaces/Enums.cs
+++ b/iRTVO.Interfaces/Enums.cs
@@ -141,7 +141,8 @@ namespace iRTVO.Interfaces
         radio,
         trigger,
         pit,
-        driverswap     // KJ: new dataset - since dataset trigger is way too volatile, we need a new dataset and can get the driverswaps within the last x seconds
+        driverswap,     // KJ: new dataset - since dataset trigger is way too volatile, we need a new dataset and can get the driverswaps within the last x seconds
+        chasedrivers    // KJ: new dataset - displays chase drivers only, valid dataorders: points, oldpoints, position, liveposition, fastestlap, previouslap
     }
 
     public enum BookmarkTypes

--- a/iRTVO.Interfaces/Enums.cs
+++ b/iRTVO.Interfaces/Enums.cs
@@ -80,7 +80,9 @@ namespace iRTVO.Interfaces
         pit,
         flag,
         state,
-        startlights
+        startlights,
+        incs2,       // KJ: for 2-inc events - sadly not recognizable
+        accident     // KJ: for 4-inc events - sadly not recognizable
     }
 
     public enum SurfaceTypes
@@ -113,7 +115,8 @@ namespace iRTVO.Interfaces
         pitOut,
         pitOccupied,
         pitEmpty,
-        init
+        driverSwap,  // KJ: pushed when driverswap occurs
+        init,        // always the last Enum for TriggerTypes!
     }
 
     public enum DataOrders
@@ -124,7 +127,8 @@ namespace iRTVO.Interfaces
         previouslap,
         classposition,
         classlaptime,
-        points,
+        points,     // order drivers by current points
+        oldpoints,  // KJ: not yet tested - orders drivers by external points standings (data.csv)
         trackposition
     }
 
@@ -136,7 +140,8 @@ namespace iRTVO.Interfaces
         points,
         radio,
         trigger,
-        pit
+        pit,
+        driverswap     // KJ: new dataset - since dataset trigger is way too volatile, we need a new dataset and can get the driverswaps within the last x seconds
     }
 
     public enum BookmarkTypes

--- a/iRTVO.Interfaces/IDriverInfo.cs
+++ b/iRTVO.Interfaces/IDriverInfo.cs
@@ -19,5 +19,8 @@ namespace iRTVO.Interfaces
         string Shortname { get;  }
         string SR { get;  }
         int UserId { get;  }
+        int TeamId { get; }         // KJ: additional Info provided by iRacing
+        string TeamName { get; }    // KJ: additional Info provided by iRacing
+        string CarName { get; }     // KJ: additional Info provided by iRacing
     }
 }

--- a/iRTVO.Interfaces/ISessionInfo.cs
+++ b/iRTVO.Interfaces/ISessionInfo.cs
@@ -38,5 +38,8 @@ namespace iRTVO.Interfaces
         double Time { get;  }
         double TimeRemaining { get;  }
         SessionTypes Type { get;  }
+        // KJ: some number juggling
+        Int32 GetFrameNumForTime(double searchtime);
+        double GetTimeForFrameNum(Int32 searchframe);
     }
 }

--- a/iRTVO.Interfaces/IStandingsItem.cs
+++ b/iRTVO.Interfaces/IStandingsItem.cs
@@ -52,5 +52,13 @@ namespace iRTVO.Interfaces
         int Speed_kph { get;  }
         double TrackPct { get;  }
         SurfaceTypes TrackSurface { get;  }
+        // KJ: incidents not yet working ...
+/*        Int32 Incidents { get; }
+        Int32 LastIncidents { get; }
+        double LastIncidentsTill { get; }
+        double IncidentThreshold { get; }
+        Int64 IncidentsReplayPos { get; } */
+        // KJ: new data
+        double LastDriverSwap { get; }
     }
 }

--- a/iRTVO.Interfaces/ITrackInfo.cs
+++ b/iRTVO.Interfaces/ITrackInfo.cs
@@ -13,6 +13,9 @@ namespace iRTVO.Interfaces
         int Id { get;  }
         float Length { get;  }
         string Name { get;  }
+        string BaseName { get; }     // KJ: additional Info provided by iRacing
+        string ShortName { get; }    // KJ: additional Info provided by iRacing
+        string Config { get; }       // KJ: additional Info provided by iRacing
         string Sky { get;  }
         float TrackTemperature { get;  }
         int Turns { get;  }

--- a/iRTVO/Code/iRacingAPI.cs
+++ b/iRTVO/Code/iRacingAPI.cs
@@ -206,18 +206,17 @@ namespace iRTVO
                         string[] external_driver;
                         if (SharedData.externalData.TryGetValue(newUserId, out external_driver))
                         {
-                            int ed_idx;
-                            if ((ed_idx = Int32.Parse(SharedData.theme.getIniValue("General", "dataFullName"))) >= 0 && external_driver.Length > ed_idx)
+                            if (SharedData.theme.dataFullName >= 0 && external_driver.Length > SharedData.theme.dataFullName)
                             {
-                                SharedData.Drivers.Find(d => d.CarIdx.Equals(carIdx)).Name = external_driver[ed_idx];
+                                SharedData.Drivers.Find(d => d.CarIdx.Equals(carIdx)).Name = external_driver[SharedData.theme.dataFullName];
                             }
-                            if ((ed_idx = Int32.Parse(SharedData.theme.getIniValue("General", "dataShortName"))) >= 0 && external_driver.Length > ed_idx)
+                            if (SharedData.theme.dataShortName >= 0 && external_driver.Length > SharedData.theme.dataShortName)
                             {
-                                SharedData.Drivers.Find(d => d.CarIdx.Equals(carIdx)).Shortname = external_driver[ed_idx];
+                                SharedData.Drivers.Find(d => d.CarIdx.Equals(carIdx)).Shortname = external_driver[SharedData.theme.dataShortName];
                             }
-                            if ((ed_idx = Int32.Parse(SharedData.theme.getIniValue("General", "dataInitials"))) >= 0 && external_driver.Length > ed_idx)
+                            if (SharedData.theme.dataInitials >= 0 && external_driver.Length > SharedData.theme.dataInitials)
                             {
-                                SharedData.Drivers.Find(d => d.CarIdx.Equals(carIdx)).Initials = external_driver[ed_idx];
+                                SharedData.Drivers.Find(d => d.CarIdx.Equals(carIdx)).Initials = external_driver[SharedData.theme.dataInitials];
                             }
                         }
 
@@ -390,22 +389,20 @@ namespace iRTVO
                             if (SharedData.externalData.TryGetValue(userId, out external_driver))
                             {
                                 // found external data for userid
-                                int ed_idx;
-                                SharedData.theme.getIniValue("General", "dataFullName");
-                                if ((ed_idx = Int32.Parse(SharedData.theme.getIniValue("General", "dataFullName"))) >= 0 && external_driver.Length > ed_idx)
+                                if (SharedData.theme.dataFullName >= 0 && external_driver.Length > SharedData.theme.dataFullName)
                                 {
                                     // fullname gets replaced with column of data.csv
-                                    driverItem.Name = external_driver[ed_idx];
+                                    driverItem.Name = external_driver[SharedData.theme.dataFullName];
                                 }
-                                if ((ed_idx = Int32.Parse(SharedData.theme.getIniValue("General", "dataShortName"))) >= 0 && external_driver.Length > ed_idx)
+                                if (SharedData.theme.dataShortName >= 0 && external_driver.Length > SharedData.theme.dataShortName)
                                 {
                                     // shortname gets replaced with column of data.csv
-                                    driverItem.Shortname = external_driver[ed_idx];
+                                    driverItem.Shortname = external_driver[SharedData.theme.dataShortName];
                                 }
-                                if ((ed_idx = Int32.Parse(SharedData.theme.getIniValue("General", "dataInitials"))) >= 0 && external_driver.Length > ed_idx)
+                                if (SharedData.theme.dataInitials >= 0 && external_driver.Length > SharedData.theme.dataInitials)
                                 {
                                     // initials get replaced with column of data.csv
-                                    driverItem.Initials = external_driver[ed_idx];
+                                    driverItem.Initials = external_driver[SharedData.theme.dataInitials];
                                 }
                             }
 

--- a/iRTVO/Code/overlay.cs
+++ b/iRTVO/Code/overlay.cs
@@ -171,11 +171,13 @@ namespace iRTVO
                 if (objects[i].Visibility == System.Windows.Visibility.Visible)
                 {
                     logger.Debug("Object {0} DataSet {1} DataOrder {2} Labels {3}", SharedData.theme.objects[i].name, SharedData.theme.objects[i].dataset, SharedData.theme.objects[i].dataorder, SharedData.theme.objects[i].labels.Length);
+
                     switch (SharedData.theme.objects[i].dataset)
                     {
+                        // KJ: datasets where the info can be found in the SessionInfo.standings
                         case DataSets.standing:
-                        case DataSets.points:
                         case DataSets.pit:
+                        case DataSets.points:
                         case DataSets.driverswap:    // KJ: new dataset driverswap
                         case DataSets.chasedrivers:  // KJ: new dataset chasedrivers
                             for (int j = 0; j < SharedData.theme.objects[i].labels.Length; j++) // items
@@ -184,172 +186,156 @@ namespace iRTVO
                                     session = SharedData.Sessions.findSessionIndexByType(SharedData.theme.objects[i].labels[j].session);
                                 else
                                     session = SharedData.OverlaySession;
+                                IEnumerable<StandingsItem> query_dataset, query_dataorder;
+                                query_dataset = SharedData.Sessions.CurrentSession.Standings.Where(s => s.LastDriverSwap > SharedData.currentSessionTime - SharedData.theme.driverSwapThreshold);
+                                query_dataorder = query_dataset.OrderBy(s => s.LastDriverSwap);
+                                int standingsCount = 0;
+                                    
                                 logger.Trace("Session = {0} ({1})", session, SharedData.Sessions.SessionList[session].Type);
+
+                                switch (SharedData.theme.objects[i].dataset)
+                                {
+                                    case DataSets.standing:
+                                        if (SharedData.theme.objects[i].carclass == null)
+                                            query_dataset = SharedData.Sessions.SessionList[session].Standings;
+                                        else
+                                            query_dataset = SharedData.Sessions.SessionList[session].Standings.Where(s => s.Driver.CarClassName == SharedData.theme.objects[i].carclass);
+                                        break;
+                                    case DataSets.pit:
+                                        // only current status available!
+                                        query_dataset = SharedData.Sessions.CurrentSession.Standings.Where(s => s.TrackSurface == SurfaceTypes.InPitStall);
+                                        break;
+                                    case DataSets.driverswap:
+                                        // only current status available!
+                                        query_dataset = SharedData.Sessions.CurrentSession.Standings.Where(s => s.LastDriverSwap >= SharedData.currentSessionTime - SharedData.theme.driverSwapThreshold);
+                                        break;
+                                    case DataSets.points:
+                                        if (SharedData.theme.pointscol == -1)
+                                        {
+                                            logger.Info("error in {0} - dataset=points but no [General] pointscol set! Defaulting to DatSets.standing ...", SharedData.theme.objects[i].name);
+                                            SharedData.theme.objects[i].dataset = DataSets.standing;
+
+                                            if (SharedData.theme.objects[i].carclass == null)
+                                                query_dataset = SharedData.Sessions.SessionList[session].Standings;
+                                            else
+                                                query_dataset = SharedData.Sessions.SessionList[session].Standings.Where(s => s.Driver.CarClassName == SharedData.theme.objects[i].carclass);
+                                        }
+                                        else
+                                        {
+                                            // only drivers in session available!
+                                            if (SharedData.theme.objects[i].dataorder == DataOrders.points)
+                                                query_dataset = SharedData.Sessions.SessionList[session].Standings.Where(s => SharedData.externalCurrentPoints.ContainsKey(s.Driver.UserId));
+                                            else
+                                                query_dataset = SharedData.Sessions.SessionList[session].Standings.Where(s => SharedData.externalPoints.ContainsKey(s.Driver.UserId));
+                                        }
+
+                                        break;
+                                    case DataSets.chasedrivers:
+                                        if (SharedData.theme.chasecol == -1)
+                                        {
+                                            logger.Info("error in {0} - dataset=chasedrivers but no [General] chasecol set! Defaulting to DataSets.standing ...",SharedData.theme.objects[i].name);
+                                            SharedData.theme.objects[i].dataset = DataSets.standing;
+
+                                            if (SharedData.theme.objects[i].carclass == null)
+                                                query_dataset = SharedData.Sessions.SessionList[session].Standings;
+                                            else
+                                                query_dataset = SharedData.Sessions.SessionList[session].Standings.Where(s => s.Driver.CarClassName == SharedData.theme.objects[i].carclass);
+                                        }
+                                        else
+                                        {
+                                            // only drivers in session available!
+                                            query_dataset = SharedData.Sessions.SessionList[session].Standings.Where(s => !(s.Driver.ExternalData[SharedData.theme.chasecol] == "false" || s.Driver.ExternalData[SharedData.theme.chasecol] == "0" || String.IsNullOrEmpty(s.Driver.ExternalData[SharedData.theme.chasecol])));
+                                        }
+
+                                        break;
+                                    default:
+                                        // no defaulting necessary - we are only in here if we detected one of these sets; still: defaulting is always good style ...
+                                        logger.Info("unknown dataset {0} in {1}! Defaulting to DataSets.standing ...",SharedData.theme.objects[i].dataset.ToString(),SharedData.theme.objects[i].name);
+                                        SharedData.theme.objects[i].dataset = DataSets.standing;
+
+                                        if (SharedData.theme.objects[i].carclass == null)
+                                            query_dataset = SharedData.Sessions.SessionList[session].Standings;
+                                        else
+                                            query_dataset = SharedData.Sessions.SessionList[session].Standings.Where(s => s.Driver.CarClassName == SharedData.theme.objects[i].carclass);
+                                        break;
+                                }
+                                
+                                // KJ: calculate querycount and pagecount
+                                standingsCount = query_dataset.Count();
+                                SharedData.theme.objects[i].pagecount = (int)Math.Ceiling((Double)standingsCount / (Double)SharedData.theme.objects[i].itemCount);
+
+                                // reached last page?
+
+                                if (SharedData.theme.objects[i].carclass != null)
+                                {
+                                    if ((SharedData.theme.objects[i].page + 1) * (SharedData.theme.objects[i].itemCount + SharedData.theme.objects[i].skip) >= SharedData.Sessions.SessionList[session].getClassCarCount(SharedData.theme.objects[i].carclass) ||
+                                        (SharedData.theme.objects[i].maxpages > 0 && SharedData.theme.objects[i].page >= SharedData.theme.objects[i].maxpages - 1))
+                                    {
+                                        SharedData.lastPage[i] = true;
+                                    }
+                                }
+                                else
+                                {
+                                    if ((SharedData.theme.objects[i].page + 1) * (SharedData.theme.objects[i].itemCount + SharedData.theme.objects[i].skip) >= standingsCount ||
+                                        (SharedData.theme.objects[i].maxpages > 0 && SharedData.theme.objects[i].page >= SharedData.theme.objects[i].maxpages - 1))
+                                    {
+                                        SharedData.lastPage[i] = true;
+                                    }
+                                }
+
+                                // fill display list
                                 for (int k = 0; k < SharedData.theme.objects[i].itemCount; k++) // drivers
                                 {
                                     int driverPos = 1 + k + ((SharedData.theme.objects[i].itemCount + SharedData.theme.objects[i].skip) * SharedData.theme.objects[i].page) + SharedData.theme.objects[i].labels[j].offset + SharedData.theme.objects[i].offset;
-                                    Int32 standingsCount = 0;
-
-                                    if (SharedData.theme.objects[i].dataset == DataSets.standing)
-                                    {
-                                        if (SharedData.theme.objects[i].carclass == null)
-                                            standingsCount = SharedData.Sessions.SessionList[session].Standings.Count;
-                                        else
-                                            standingsCount = SharedData.Sessions.SessionList[session].getClassCarCount(SharedData.theme.objects[i].carclass);
-                                    }
-                                    else if (SharedData.theme.objects[i].dataset == DataSets.points)
-                                    {
-                                        // KJ: experimental - we can also sort by external points without new calculation
-                                        if (SharedData.theme.objects[i].dataorder == DataOrders.points)
-                                            standingsCount = SharedData.externalCurrentPoints.Count;
-                                        else
-                                            standingsCount = SharedData.externalPoints.Count;
-                                    }
-                                    else if (SharedData.theme.objects[i].dataset == DataSets.pit)
-                                    {
-
-                                        standingsCount = SharedData.Sessions.SessionList[session].Standings.Count(c => c.TrackSurface == SurfaceTypes.InPitStall);
-                                        logger.Debug("Pit detected count={0}", standingsCount);
-                                    }
-                                    // KJ: new dataset driverswap
-                                    else if (SharedData.theme.objects[i].dataset == DataSets.driverswap)
-                                    {
-                                        standingsCount = SharedData.Sessions.CurrentSession.Standings.Count(s => s.LastDriverSwap > SharedData.currentSessionTime - SharedData.theme.driverSwapThreshold);
-                                        logger.Debug("driverswaps within last {0} seconds detected: {1}", SharedData.currentSessionTime - SharedData.theme.driverSwapThreshold);
-                                    }
-                                    // KJ: new dataset chasedrivers
-                                    else if (SharedData.theme.objects[i].dataset == DataSets.chasedrivers)
-                                    {
-                                        IEnumerable<StandingsItem> query = SharedData.Sessions.CurrentSession.Standings.Where(s => (s.Driver.ExternalData[(int)SharedData.theme.chasecol] != "false" && s.Driver.ExternalData[(int)SharedData.theme.chasecol] != "0" && !String.IsNullOrEmpty(s.Driver.ExternalData[(int)SharedData.theme.chasecol])));
-                                        standingsCount = query.Count();
-                                    }
-
-                                    SharedData.theme.objects[i].pagecount = (int)Math.Ceiling((Double)standingsCount / (Double)SharedData.theme.objects[i].itemCount);
-
-                                    if (SharedData.theme.objects[i].carclass != null)
-                                    {
-                                        if ((SharedData.theme.objects[i].page + 1) * (SharedData.theme.objects[i].itemCount + SharedData.theme.objects[i].skip) >= SharedData.Sessions.SessionList[session].getClassCarCount(SharedData.theme.objects[i].carclass) ||
-                                            (SharedData.theme.objects[i].maxpages > 0 && SharedData.theme.objects[i].page >= SharedData.theme.objects[i].maxpages - 1))
-                                        {
-                                            SharedData.lastPage[i] = true;
-                                        }
-                                    }
-                                    else
-                                    {
-                                        if ((SharedData.theme.objects[i].page + 1) * (SharedData.theme.objects[i].itemCount + SharedData.theme.objects[i].skip) >= standingsCount ||
-                                            (SharedData.theme.objects[i].maxpages > 0 && SharedData.theme.objects[i].page >= SharedData.theme.objects[i].maxpages - 1))
-                                        {
-                                            SharedData.lastPage[i] = true;
-                                        }
-                                    }
-
                                     if (driverPos <= standingsCount)
                                     {
                                         labels[i][(j * SharedData.theme.objects[i].itemCount) + k].Visibility = System.Windows.Visibility.Visible;                                        
 
                                         StandingsItem driver = new StandingsItem();
 
-                                        if (SharedData.theme.objects[i].dataset == DataSets.standing)
+                                        switch (SharedData.theme.objects[i].dataorder)
                                         {
-                                            if (SharedData.Sessions.SessionList[session].Type != SessionTypes.race && SharedData.theme.objects[i].dataorder == DataOrders.liveposition)
-                                                driver = SharedData.Sessions.SessionList[session].FindPosition(driverPos, DataOrders.position, SharedData.theme.objects[i].carclass);
-                                            else
-                                                driver = SharedData.Sessions.SessionList[session].FindPosition(driverPos, SharedData.theme.objects[i].dataorder, SharedData.theme.objects[i].carclass);
+                                            case DataOrders.fastestlap:
+                                                query_dataorder = query_dataset.OrderBy(s => s.FastestLap);
+                                                break;
+                                            case DataOrders.liveposition:
+                                                query_dataorder = query_dataset.OrderBy(s => s.PositionLive);
+                                                break;
+                                            case DataOrders.oldpoints:
+                                                query_dataorder = query_dataset.OrderBy(s => Int32.Parse(s.Driver.ExternalData[SharedData.theme.pointscol]));
+                                                break;
+                                            case DataOrders.points:
+                                                query_dataorder = query_dataset.OrderBy(s => SharedData.externalCurrentPoints[s.Driver.UserId]);
+                                                break;
+                                            case DataOrders.position:
+                                                query_dataorder = query_dataset.OrderBy(s => s.Position);
+                                                break;
+                                            case DataOrders.previouslap:
+                                                query_dataorder = query_dataset.OrderBy(s => s.PreviousLap);
+                                                break;
+                                            case DataOrders.trackposition:
+                                                query_dataorder = query_dataset.OrderByDescending(s => s.TrackPct);
+                                                break;
+                                            case DataOrders.classposition:
+                                                if (SharedData.theme.objects[i].carclass == null)
+                                                    query_dataorder = query_dataset.OrderBy(s => s.Driver.CarClass).OrderBy(s => s.Position);
+                                                else
+                                                    query_dataorder = query_dataset.OrderBy(s => s.Position);  // query already reduced to one specific car class
+                                                break;
+                                            case DataOrders.classlaptime:
+                                                if (SharedData.theme.objects[i].carclass == null)
+                                                    query_dataorder = query_dataset.OrderBy(s => s.Driver.CarClass).OrderBy(s => s.FastestLap);
+                                                else
+                                                    query_dataorder = query_dataset.OrderBy(s => s.FastestLap);  // query already reduced to one specific car class
+                                                break;
+                                            default:
+                                                // well, there shouldn't be any defaulting necessary
+                                                logger.Info("dataorder {0} in {1} unknown! Defaulting to DataOrders.position ...",SharedData.theme.objects[i].dataorder.ToString(),SharedData.theme.objects[i].name);
+                                                query_dataorder = query_dataset.OrderBy(s => s.Position);
+                                                break;
                                         }
-                                        else if (SharedData.theme.objects[i].dataset == DataSets.points)
-                                        {
-                                            // KJ: experimental - sort by current points or standings before the race
-                                            KeyValuePair<int, int> item;
 
-                                            if (SharedData.theme.objects[i].dataorder == DataOrders.oldpoints)
-                                                item = SharedData.externalPoints.OrderByDescending(key => key.Value).Skip(driverPos - 1).FirstOrDefault();
-                                            else
-                                                item = SharedData.externalCurrentPoints.OrderByDescending(key => key.Value).Skip(driverPos - 1).FirstOrDefault();
-
-                                            driver = SharedData.Sessions.SessionList[session].Standings.SingleOrDefault(si => si.Driver.UserId == item.Key);
-
-                                            if (driver == null)
-                                            {
-                                                driver = new StandingsItem();
-                                                driver.Driver.UserId = item.Key;
-                                                // KJ: ok, let's check if some of the data is to be overwritten by data from data.csv
-                                                string[] external_driver;
-                                                if (SharedData.externalData.TryGetValue(item.Key, out external_driver))
-                                                {
-                                                    if (SharedData.theme.dataFullName >= 0 && external_driver.Length > SharedData.theme.dataFullName)
-                                                    {
-                                                        // fullname gets replaced with column of data.csv
-                                                        driver.Driver.Name = external_driver[SharedData.theme.dataFullName];
-                                                    }
-                                                    if (SharedData.theme.dataShortName >= 0 && external_driver.Length > SharedData.theme.dataShortName)
-                                                    {
-                                                        // shortname gets replaced with column of data.csv
-                                                        driver.Driver.Shortname = external_driver[SharedData.theme.dataShortName];
-                                                    }
-                                                    if (SharedData.theme.dataInitials >= 0 && external_driver.Length > SharedData.theme.dataInitials)
-                                                    {
-                                                        // initials get replaced with column of data.csv
-                                                        driver.Driver.Initials = external_driver[SharedData.theme.dataInitials];
-                                                    }
-                                                }
-                                            }
-                                        }
-                                        else if (SharedData.theme.objects[i].dataset == DataSets.pit)
-                                        {
-                                            /* var tmpItem = from st in SharedData.Sessions.SessionList[session].Standings
-                                                          where
-                                                              st.TrackSurface == SurfaceTypes.InPitStall
-                                                          select st;
-                                            driver = tmpItem.Skip(driverPos - 1).FirstOrDefault(); */
-                                            if (SharedData.theme.objects[i].dataorder == DataOrders.liveposition)
-                                                driver = SharedData.Sessions.SessionList[session].Standings.Where(s => s.TrackSurface == SurfaceTypes.InPitStall).OrderBy(s => s.PositionLive).Skip(driverPos - 1).FirstOrDefault();
-                                            else if (SharedData.theme.objects[i].dataorder == DataOrders.oldpoints)
-                                                driver = SharedData.Sessions.SessionList[session].Standings.Where(s => s.TrackSurface == SurfaceTypes.InPitStall).OrderByDescending(s => s.Driver.ExternalData[SharedData.theme.pointscol]).Skip(driverPos - 1).FirstOrDefault();
-                                            else if (SharedData.theme.objects[i].dataorder == DataOrders.points)
-                                                driver = SharedData.Sessions.SessionList[session].Standings.Where(s => s.TrackSurface == SurfaceTypes.InPitStall).OrderByDescending(s => s.Driver.ExternalData[SharedData.theme.pointscol] + SharedData.theme.pointschema[s.Position]).Skip(driverPos - 1).FirstOrDefault();
-                                            else if (SharedData.theme.objects[i].dataorder == DataOrders.position)
-                                                driver = SharedData.Sessions.SessionList[session].Standings.Where(s => s.TrackSurface == SurfaceTypes.InPitStall).OrderBy(s => s.Position).Skip(driverPos - 1).FirstOrDefault();
-                                            else  // default: by position "on track", 
-                                                driver = SharedData.Sessions.SessionList[session].Standings.Where(s => s.TrackSurface == SurfaceTypes.InPitStall).OrderByDescending(s => s.TrackPct + ((s.TrackPct < 0.5) ? 1 : 0)).Skip(driverPos - 1).FirstOrDefault();
-                                            logger.Debug("PIT driver==null = {0}", driver);
-                                            if ( driver == null )
-                                                continue;
-
-                                        }
-                                        // KJ: new dataset driverswap - able to show the driverswaps in the last x (10) seconds
-                                        else if (SharedData.theme.objects[i].dataset == DataSets.driverswap)
-                                        {
-                                            /* var tmpItem = from st in SharedData.Sessions.SessionList[session].Standings.OrderByDescending(s => s.LastDriverSwap)
-                                                          where
-                                                              st.LastDriverSwap > SharedData.currentSessionTime - 10.0
-                                                          select st;
-                                            driver = tmpItem.Skip(driverPos - 1).FirstOrDefault(); */
-                                            driver = SharedData.Sessions.SessionList[session].Standings.OrderByDescending(s => s.LastDriverSwap).Where(s => s.LastDriverSwap > SharedData.currentSessionTime - SharedData.theme.driverSwapThreshold).Skip(driverPos - 1).FirstOrDefault();
-                                            logger.Debug("DRIVERSWAP driver == null = {0}", driver);
-                                            if (driver == null)
-                                                continue;
-                                        }
-                                        // KJ: new dataset chasedrivers
-                                        else if (SharedData.theme.objects[i].dataset == DataSets.chasedrivers)
-                                        {
-                                            KeyValuePair<int, int> item;
-
-                                            if (SharedData.theme.objects[i].dataorder == DataOrders.position)
-                                                driver = SharedData.Sessions.CurrentSession.Standings.Where(s => (s.Driver.ExternalData[(int)SharedData.theme.chasecol] != "false" && s.Driver.ExternalData[(int)SharedData.theme.chasecol] != "0" && !String.IsNullOrEmpty(s.Driver.ExternalData[(int)SharedData.theme.chasecol]))).OrderBy(s => s.Position).Skip(driverPos - 1).FirstOrDefault();
-                                            else if (SharedData.theme.objects[i].dataorder == DataOrders.liveposition)
-                                                driver = SharedData.Sessions.CurrentSession.Standings.Where(s => (s.Driver.ExternalData[(int)SharedData.theme.chasecol] != "false" && s.Driver.ExternalData[(int)SharedData.theme.chasecol] != "0" && !String.IsNullOrEmpty(s.Driver.ExternalData[(int)SharedData.theme.chasecol]))).OrderBy(s => s.PositionLive).Skip(driverPos - 1).FirstOrDefault();
-                                            else if (SharedData.theme.objects[i].dataorder == DataOrders.points)
-                                                driver = SharedData.Sessions.SessionList[session].Standings.OrderByDescending(s => s.Driver.ExternalData[SharedData.theme.pointscol] + SharedData.theme.pointschema[s.Position]).Where(s => (s.Driver.ExternalData[(int)SharedData.theme.chasecol] != "false" && s.Driver.ExternalData[(int)SharedData.theme.chasecol] != "0" && !String.IsNullOrEmpty(s.Driver.ExternalData[(int)SharedData.theme.chasecol]))).Skip(driverPos - 1).FirstOrDefault();
-                                            else if (SharedData.theme.objects[i].dataorder == DataOrders.fastestlap)
-                                                driver = SharedData.Sessions.SessionList[session].Standings.OrderBy(s => s.FastestLap).Where(s => (s.Driver.ExternalData[(int)SharedData.theme.chasecol] != "false" && s.Driver.ExternalData[(int)SharedData.theme.chasecol] != "0" && !String.IsNullOrEmpty(s.Driver.ExternalData[(int)SharedData.theme.chasecol]))).Skip(driverPos - 1).FirstOrDefault();
-                                            else if (SharedData.theme.objects[i].dataorder == DataOrders.previouslap)
-                                                driver = SharedData.Sessions.SessionList[session].Standings.OrderBy(s => s.PreviousLap).Where(s => (s.Driver.ExternalData[(int)SharedData.theme.chasecol] != "false" && s.Driver.ExternalData[(int)SharedData.theme.chasecol] != "0" && !String.IsNullOrEmpty(s.Driver.ExternalData[(int)SharedData.theme.chasecol]))).Skip(driverPos - 1).FirstOrDefault();
-                                            else // if (SharedData.theme.objects[i].dataorder == DataOrders.oldpoints)  // oldpoints is our default order for this dataset
-                                                driver = SharedData.Sessions.SessionList[session].Standings.OrderByDescending(s => s.Driver.ExternalData[SharedData.theme.pointscol]).Where(s => (s.Driver.ExternalData[(int)SharedData.theme.chasecol] != "false" && s.Driver.ExternalData[(int)SharedData.theme.chasecol] != "0" && !String.IsNullOrEmpty(s.Driver.ExternalData[(int)SharedData.theme.chasecol]))).Skip(driverPos - 1).FirstOrDefault();
-                                            logger.Debug("CHASEDRIVERS driver == null = {0}", driver);
-                                            if (driver == null)
-                                                continue;
-                                        }
+                                        driver = query_dataorder.Skip(driverPos - 1).FirstOrDefault();
 
                                         labels[i][(j * SharedData.theme.objects[i].itemCount) + k].Content = SharedData.theme.formatFollowedText(
                                             SharedData.theme.objects[i].labels[j],
@@ -390,6 +376,7 @@ namespace iRTVO
                             }
                             break;
 
+                        // scope is session information:
                         case DataSets.sessionstate:
                             for (int j = 0; j < SharedData.theme.objects[i].labels.Length; j++)
                             {
@@ -424,6 +411,8 @@ namespace iRTVO
                                 }
                             }
                             break;
+
+                        // scope is one specific driver - followed, radio (who is sending), trigger (who triggered the most recent event)
                         default:
                         case DataSets.followed:
                         case DataSets.radio:

--- a/iRTVO/Data/Bookmark.cs
+++ b/iRTVO/Data/Bookmark.cs
@@ -21,7 +21,7 @@ namespace iRTVO.Data
         public Int32 PlaySpeed { get; set; }
         public String Description { get; set; }
         public String DriverName { get; set; }
-        public Int32 SessionNum { get; set; }
+        public Int32 SessionNum { get; set; }       // KJ: needed for rewritten "REWIND" broadcast
 
         public BookmarkTypes BookmarkType { get; set; }
 
@@ -36,7 +36,7 @@ namespace iRTVO.Data
             CamIdx = SharedData.currentCam;
             DriverIdx = ev.Driver.NumberPlatePadded;
             PlaySpeed = 0;
-
+            SessionNum = ev.SessionNumber;      // KJ: needed for rewritten "REWIND" broadcast
         }
     }
 

--- a/iRTVO/Data/DriverInfo.cs
+++ b/iRTVO/Data/DriverInfo.cs
@@ -23,6 +23,7 @@ namespace iRTVO.Data
         int userId;
         int teamId;        // KJ:
         string teamName;   // KJ:
+        string carName;    // KJ:
         int carId;
         int carclass;
 
@@ -41,9 +42,10 @@ namespace iRTVO.Data
             userId = 0;
             carId = 0;
             numberPlate = "0";
-            // KJ: teamid and teamname
+            // KJ: teamid, teamname, carname
             teamId = 0;
             teamName = "";
+            carName = "";
         }
 
         public string Name { get { return name; } set { name = value; } }
@@ -62,9 +64,10 @@ namespace iRTVO.Data
         public int CarId { get { return carId; } set { carId = value; } }
         public int CarClass { get { return carclass; } set { carclass = value; } }
         public string CarClassName { get { return carclassname; } set { carclassname = value; } }
-        // KJ: teamid and teamname
+        // KJ: teamid, teamname, carname
         public int TeamId { get { return teamId; } set { teamId = value; } }
         public string TeamName { get { return teamName; } set { teamName = value; } }
+        public string CarName { get { return carName; } set { carName = value; } }
 
         public string[] ExternalData
         {

--- a/iRTVO/Data/SessionEvent.cs
+++ b/iRTVO/Data/SessionEvent.cs
@@ -26,13 +26,14 @@ namespace iRTVO.Data
         SessionTypes session;
         Int32 lapnum;
         Int32 rewind;
+        Int32 sessionNumber;   // KJ: needed for rewritten REWIND functionality
 
         public SessionEvent()
         {
 
         }
 
-        public SessionEvent(SessionEventTypes type, Int64 replay, DriverInfo driver, String desc, SessionTypes session, Int32 lap)
+        public SessionEvent(SessionEventTypes type, Int64 replay, DriverInfo driver, String desc, SessionTypes session, Int32 lap, Int32 sessionnum)
         {
             this.type = type;
             this.timestamp = DateTime.Now;
@@ -42,6 +43,7 @@ namespace iRTVO.Data
             this.session = session;
             this.lapnum = lap;
             this.rewind = 0;
+            this.sessionNumber = sessionnum;   // KJ: needed for rewritten REWIND functionality
         }
 
         public String Session { get { return this.session.ToString(); } set { } }
@@ -52,10 +54,10 @@ namespace iRTVO.Data
         public SessionEventTypes EventType { get { return this.type; } set { } }
         public Int32 Lap { get { return this.lapnum; } set { } }
         public Int32 Rewind { get { return this.rewind; } set { this.rewind = value; } }
+        public Int32 SessionNumber { get { return this.sessionNumber; } set { this.sessionNumber = value; } }   // KJ: needed for rewritten REWIND functionality
 
 
         IDriverInfo ISessionEvent.Driver { get { return Driver as IDriverInfo; } }
     }
-
     
 }

--- a/iRTVO/Data/Settings.cs
+++ b/iRTVO/Data/Settings.cs
@@ -86,6 +86,8 @@ namespace iRTVO.Data
         public Int32 WebTimingUpdateInterval = 10;
         [CfgSetting(Section = "WebTiming", Entry = "Enable", DefaultValue = "False")]
         public Boolean WebTimingEnable = false;
+        [CfgSetting(Section = "WebTiming", Entry = "webTimingCompression", DefaultValue = "False")]    // compression for webtiming - not yet implemented!
+        public Boolean webTimingCompression = false;
 
         [CfgSetting(Section = "Windows", Entry = "AlwaysOnTopMainWindow", DefaultValue = "False")]
         public Boolean AlwaysOnTopMainWindow = false;

--- a/iRTVO/Data/SharedData.cs
+++ b/iRTVO/Data/SharedData.cs
@@ -76,6 +76,7 @@ namespace iRTVO.Data
         public static WebTiming.webTiming web;
         public static Int64 webBytes = 0;
         public static String webError = "";
+        public static List<int> webKnownUserIds;  // KJ: for reducing data-width in webTiming (in future release)
 
         // Data
         public static List<DriverInfo> Drivers = new List<DriverInfo>();

--- a/iRTVO/Data/StandingsItem.cs
+++ b/iRTVO/Data/StandingsItem.cs
@@ -1,4 +1,5 @@
 ﻿using iRTVO.Interfaces;
+using iRSDKSharp;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -49,6 +50,15 @@ namespace iRTVO.Data
         Int32 airTimeCount = 0;
         TimeSpan airTimeAirTime = TimeSpan.FromMilliseconds(0.0);
         DateTime airTimeLastAirTime = DateTime.MinValue;
+
+        // KJ: incident-markers and driver-swap timestamp - sadly enough the incident-markers are pretty useless, since other than OffTrack we can't really get incs in real time  :(
+        Int32 incidents = 0;
+        Int32 lastIncidents = 0;
+        Int64 incidentsReplayPos = 0;
+        double lastIncidentsTill = 0.0;
+        double incidentThreshold = 3.0;
+
+        double lastDriverSwap = 0.0;
 
         public StandingsItem()
         {
@@ -108,7 +118,8 @@ namespace iRTVO.Data
                                             driver,
                                             "Off track",
                                             SharedData.Sessions.CurrentSession.Type,
-                                            CurrentLap.LapNum
+                                            CurrentLap.LapNum,
+                                            SharedData.Sessions.CurrentSession.Id    // KJ: additional data for rewritten "REWIND" broadcast
                                         );
                     SharedData.Events.Add(ev);
                     SharedData.triggers.Push(new TriggerInfo { CarIdx = driver.CarIdx, Trigger = TriggerTypes.offTrack });
@@ -149,7 +160,8 @@ namespace iRTVO.Data
                                             Driver,
                                             "Pitting on lap " + CurrentLap.LapNum,
                                             SharedData.Sessions.CurrentSession.Type,
-                                            CurrentLap.LapNum
+                                            CurrentLap.LapNum,
+                                            SharedData.Sessions.CurrentSession.Id     // KJ: additional data for rewritten "REWIND" Broadcast
                                         );
                                     SharedData.Events.Add(ev);
                                     PitStops++;
@@ -185,6 +197,15 @@ namespace iRTVO.Data
         public TimeSpan AirTimeAirTime { get { return airTimeAirTime; } set { airTimeAirTime = value; NotifyPropertyChanged("AirTimeAirTime"); NotifyPropertyChanged("AirTimeAirTime_HR"); } }
         public String AirTimeAirTime_HR { get { return String.Format("{0:hh\\:mm\\:ss}", airTimeAirTime); } }
         public DateTime AirTimeLastAirTime { get { return airTimeLastAirTime; } }
+
+        // KJ: incident-markers and driver-swap timestamp - sadly enough the incident-markers are pretty useless, since other than OffTrack we can't really get incs in real time  :(
+        public Int32 Incidents { get { return incidents; } set { incidents = value; } }
+        public Int32 LastIncidents { get { return lastIncidents; } set { lastIncidents = value; } }
+        public double LastIncidentsTill { get { return lastIncidentsTill; } set { lastIncidentsTill = value; } }
+        public double IncidentThreshold { get { return incidentThreshold; } set { incidentThreshold = value; } }
+        public Int64 IncidentsReplayPos { get { return incidentsReplayPos; } set { incidentsReplayPos = value; } }
+
+        public double LastDriverSwap { get { return lastDriverSwap; } set { lastDriverSwap = value; } }
 
         public void AddAirTime(Double howmuch)
         {

--- a/iRTVO/Data/TrackInfo.cs
+++ b/iRTVO/Data/TrackInfo.cs
@@ -37,6 +37,29 @@ namespace iRTVO.Data
             set { name = value; }
         }
 
+        // KJ: ok, additional data pulled from iRacing (well, actually they provide it the same way as the other track data, so let's use it!)
+        private String baseName = "";
+
+        public String BaseName
+        {
+            get { return baseName; }
+            set { baseName = value; }
+        }
+        private String shortName = "";
+
+        public String ShortName
+        {
+            get { return shortName; }
+            set { shortName = value; }
+        }
+        private String config = "";
+
+        public String Config
+        {
+            get { return config; }
+            set { config = value; }
+        }
+
         private String city = "";
 
         public String City

--- a/iRTVO/Properties/AssemblyInfo.cs
+++ b/iRTVO/Properties/AssemblyInfo.cs
@@ -7,7 +7,7 @@ using System.Windows;
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("iRacing TV Overlay 1.3.0-RC10")]
+[assembly: AssemblyTitle("iRacing TV Overlay 1.3.0-RC11")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]

--- a/iRTVO/UI/lists.xaml
+++ b/iRTVO/UI/lists.xaml
@@ -85,6 +85,8 @@
                             <DataGridTextColumn Header="Fastest" Binding="{Binding FastestLap_HR}" />
                             <DataGridTextColumn Header="P" Binding="{Binding PitStops}" />
                             <DataGridTextColumn Header="Pit Time" Binding="{Binding PitStopTime, StringFormat='{}{0:#.#}'}" />
+                            <DataGridTextColumn Header="OnAir" Binding="{Binding AirTimeAirTime_HR}" />
+                            <DataGridTextColumn Header="LastOnAir" Binding="{Binding AirTimeLastAirTime}" />
                         </DataGrid.Columns>
                     </DataGrid>
                 </Grid>


### PR DESCRIPTION
- teamname from iR Data
- classname/carname from iR Data
- iR Data is now fallback for tracks.ini, cars.ini, teams.csv
- new dataset driverswap
- new trigger driverswap
- triggers can push buttons
- triggers can be deactivated/activated
- triggers can be grouped - new [General] property triggergroups
- additional text properties (like {fl_...} for fastest lap data in
  sessiondata
- new dataorder oldpoints
- "REWIND" broadcast now with sessionnum/sessiontime instead of relative
  framecount
- ...

I also took the liberty to raise the version to RC11
